### PR TITLE
Multiaddr Update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,10 +32,10 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
 
         // LibP2P Core Modules
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMajor(from: "0.1.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.2.0")),
 
         // NIO Extras
-        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-extras.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/LibP2PTCP/LibP2PTCP.swift
+++ b/Sources/LibP2PTCP/LibP2PTCP.swift
@@ -61,7 +61,7 @@ public struct TCP_Embedded: Transport {
                 channel: channel,
                 direction: .outbound,
                 remoteAddress: address,
-                expectedRemotePeer: try? PeerID(cid: address.getPeerID() ?? "")
+                expectedRemotePeer: try? address.getPeerID()
             )
 
             /// The connection installs the necessary channel handlers here


### PR DESCRIPTION
### What:
- Updated `getPeerID` to support the latest `Multiaddr` release
https://github.com/swift-libp2p/swift-multiaddr/releases/tag/0.1.0

### Why:
- https://github.com/swift-libp2p/swift-multiaddr/issues/14

### Breaking Changes
```swift
// From
Multiaddr.getPeerID() -> String?

// To
Multiaddr.getPeerID() throws -> PeerID
```