### PR TITLE
Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the swift-libp2p open source project

--- a/Package.swift
+++ b/Package.swift
@@ -32,10 +32,10 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
 
         // LibP2P Core Modules
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.3.0")),
 
         // NIO Extras
-        .package(url: "https://github.com/apple/swift-nio-extras.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/apple/swift-nio-extras.git", .upToNextMajor(from: "1.25.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/LibP2PTCP/Client/TCPClient.swift
+++ b/Sources/LibP2PTCP/Client/TCPClient.swift
@@ -15,9 +15,10 @@
 import LibP2P
 import Logging
 import NIO
+import NIOConcurrencyHelpers
 
-public struct TCPClient: Client {
-    public static var key: String = "TCPClient"
+public struct TCPClient: Client, @unchecked Sendable {
+    public static let key: String = "TCPClient"
     private let provider: NIOEventLoopGroupProvider
 
     public let eventLoop: EventLoop
@@ -77,15 +78,15 @@ public struct TCPClient: Client {
         EventLoopTCPClient(tcp: self, eventLoop: eventLoop, logger: self.logger)
     }
 
-    public struct Configuration {
-        var example: String
+    public struct Configuration: Sendable {
+        let example: NIOLockedValueBox<String>
 
         public init(example: String = "default") {
-            self.example = example
+            self.example = .init(example)
         }
     }
 
-    public enum Errors: Error {
+    public enum Errors: Error, Sendable {
         case notImplementedYet
         case invalidMultiaddrForTransport
     }

--- a/Sources/LibP2PTCP/LibP2PTCP.swift
+++ b/Sources/LibP2PTCP/LibP2PTCP.swift
@@ -17,8 +17,8 @@ import Multiaddr
 import Multicodec
 
 // Install our TCP Tranport on the LibP2P Application
-public struct TCP_Embedded: Transport {
-    public static var key: String = "tcp"
+public struct TCP_Embedded: Transport, @unchecked Sendable {
+    public static let key: String = "tcp"
 
     let application: Application
     public var protocols: [LibP2PProtocol]
@@ -84,7 +84,7 @@ public struct TCP_Embedded: Transport {
     public func canDial(address: Multiaddr) -> Bool {
         //address.tcpAddress != nil && !address.protocols().contains(.ws)
         guard let tcp = address.tcpAddress else { return false }
-        // Remove once we can dial ipv6 addresses
+        // TODO: Remove once we can dial ipv6 addresses
         guard tcp.ip4 else { return false }
         // Our TCP Client doesn't support WebSocket Upgrades...
         guard !address.protocols().contains(.ws) else { return false }

--- a/Sources/LibP2PTCP/Server/Application+TCP+Server.swift
+++ b/Sources/LibP2PTCP/Server/Application+TCP+Server.swift
@@ -15,13 +15,13 @@
 import LibP2P
 
 extension Application.Servers.Provider {
-    public static var tcp: Self {
+    public static var tcp_embedded: Self {
         .init {
             $0.servers.use { $0.tcp.server.shared }
         }
     }
 
-    public static func tcp(host: String, port: Int) -> Self {
+    public static func tcp_embedded(host: String, port: Int) -> Self {
         .init {
             $0.tcp.server.configuration = TCPServer.Configuration(
                 address: .hostname(host, port: port),

--- a/Sources/LibP2PTCP/Server/TCPServer.swift
+++ b/Sources/LibP2PTCP/Server/TCPServer.swift
@@ -17,15 +17,15 @@ import Logging
 import NIO
 import NIOExtras
 
-public final class TCPServer: Server {
-    public static var key: String = "TCP"
+public final class TCPServer: Server, @unchecked Sendable {
+    public static let key: String = "TCP"
 
     /// Engine server config struct.
     ///
     ///     let serverConfig = TCPServerConfig.default(port: 8123)
     ///     services.register(serverConfig)
     ///
-    public struct Configuration {
+    public struct Configuration: @unchecked Sendable {
         public static let defaultHostname = "127.0.0.1"
         public static let defaultPort = 10000
 
@@ -253,7 +253,7 @@ public final class TCPServer: Server {
     }
 }
 
-private final class TCPServerConnection {
+private final class TCPServerConnection: Sendable {
     let channel: Channel
     let quiesce: ServerQuiescingHelper
 

--- a/Tests/LibP2PTCPTests/LibP2PTCPTests.swift
+++ b/Tests/LibP2PTCPTests/LibP2PTCPTests.swift
@@ -12,15 +12,27 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import LibP2P
+import Testing
 
 @testable import LibP2PTCP
 
-final class LibP2PTCPTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        //XCTAssertEqual(LibP2PTCP().text, "Hello, World!")
+@Suite("Libp2p TCP Tests")
+struct LibP2PTCPTests {
+
+    @Test func testTCP() async throws {
+        let app = Application(.testing)
+
+        app.servers.use(.tcp_embedded)
+
+        try await app.startup()
+
+        #expect(app.environment == Environment.testing)
+        #expect(try app.listenAddresses == [Multiaddr("/ip4/127.0.0.1/tcp/10000")])
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        try await app.asyncShutdown()
     }
+
 }


### PR DESCRIPTION
### What
- Bumps spm to 6.0 ([libp2p will start supporting the latest 3 versions of swift similar to swift-nio](https://github.com/apple/swift-nio?tab=readme-ov-file#swift-versions))
- Migrates from `XCTest` to [Testing](https://github.com/swiftlang/swift-testing)
- Adds `Sendable` conformance to necessary types

### Breaking Changes
> [!WARNING]
> - There are a few classes that use `@unchecked Sendable`. They *should* be thread safe due to their original design (constrained to a particular nio eventloop)
> - This PR requires a minor version bump and depends on the +0.2.0 series of support dependencies and +0.3.0 of swift-libp2p